### PR TITLE
Fixed GET logout method. Changed to POST.

### DIFF
--- a/example/account/index.js
+++ b/example/account/index.js
@@ -95,7 +95,7 @@ var Account = module.exports = Service.extend({
       }
     },
 
-    'get::^/logout': function logout(req, res) {
+    'post::^/logout': function logout(req, res) {
       req.logout();
       res.redirect('/account/login');
     },

--- a/example/account/view/hello.jade
+++ b/example/account/view/hello.jade
@@ -1,4 +1,5 @@
 h2  /account/protected
 h3  Hello #{name}, you can not see this page unless you have logged in successfully.
 h4  Click to
-  a(href="/logout")  Logout
+form(action="/logout", method="POST")
+  button(type="submit") Logout


### PR DESCRIPTION
Explain me please why did you make logout using `GET /logout`?

It's not safe. Anyone can insert a picture `<img src="http://yousite.com/logout" />` and your users will logged out.

It may be better to do `POST /logout`?